### PR TITLE
Fix modal closing behavior when dragging

### DIFF
--- a/src/public/client.js
+++ b/src/public/client.js
@@ -533,11 +533,15 @@ function setupModals() {
         });
     });
 
-    // Close modal when clicking outside
-    window.addEventListener('click', (event) => {
-        if (event.target.classList.contains('modal')) {
+    let mouseDownOnModal = false;
+    window.addEventListener('mousedown', (event) => {
+        mouseDownOnModal = event.target.classList.contains('modal');
+    });
+    window.addEventListener('mouseup', (event) => {
+        if (mouseDownOnModal && event.target.classList.contains('modal')) {
             hideModal(event.target.id);
         }
+        mouseDownOnModal = false;
     });
 
     // Close modal with Escape key


### PR DESCRIPTION
Fix modal closing behavior when dragging

## Bug Fixed
Previously, when a user started a drag operation inside a modal's content and released their mouse outside the content (but still on the modal background), the modal would unexpectedly close. This created a poor user experience, especially when trying to select text or interact with modal content like input change in #34.

## Changes
- Added tracking of where mouse clicks begin using the mousedown event
- Only close modals when both mousedown AND mouseup events occur on the modal background
- Prevents accidental modal closing when dragging from content to background