### PR TITLE
Add implementation for #67

### DIFF
--- a/src/conversationManager.ts
+++ b/src/conversationManager.ts
@@ -448,7 +448,7 @@ export class ConversationManager {
             };
             try {
                 const results = await client.callTool(params, CallToolResultSchema, { timeout: this.toolCallTimeoutSec * 1000 });
-                
+
                 // Enhanced content processing for images and mixed content
                 if (results.content instanceof Array && results.content.length !== 0) {
                     const processedContent: (TextBlockParam | ImageBlockParam)[] = [];
@@ -456,13 +456,13 @@ export class ConversationManager {
                         type: 'text',
                         text: `Tool "${params.name}" executed successfully. Results:`,
                     });
-                    
+
                     for (const item of results.content) {
                         if (item.type === 'image' && item.data) {
                             // Detect image format from base64 data
                             const imageData = item.data;
                             let mediaType: 'image/png' | 'image/jpeg' | 'image/webp' | 'image/gif' = 'image/png';
-                            
+
                             try {
                                 // Check the base64 data signature to determine format
                                 const header = imageData.substring(0, 20);
@@ -517,7 +517,7 @@ export class ConversationManager {
                             });
                         }
                     }
-                    
+
                     toolResultBlock.content = processedContent;
                 } else {
                     toolResultBlock.content = [{

--- a/src/conversationManager.ts
+++ b/src/conversationManager.ts
@@ -352,6 +352,7 @@ export class ConversationManager {
                                 // Detect image format from base64 data
                                 const imageData = item.data;
                                 let mediaType = 'image/png';
+                                // Anthropic's API requires the correct MIME 
                                 
                                 try {
                                     // Check the base64 data signature to determine format

--- a/src/conversationManager.ts
+++ b/src/conversationManager.ts
@@ -6,7 +6,7 @@
 import { Anthropic } from '@anthropic-ai/sdk';
 import type { ContentBlockParam, Message, MessageParam, TextBlockParam, ImageBlockParam } from '@anthropic-ai/sdk/resources/messages';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { ListToolsResult, Notification } from '@modelcontextprotocol/sdk/types.js';
+import type { ListToolsResult, Notification, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { log } from 'apify';
 import { EventSource } from 'eventsource';
@@ -448,83 +448,14 @@ export class ConversationManager {
             };
             try {
                 const results = await client.callTool(params, CallToolResultSchema, { timeout: this.toolCallTimeoutSec * 1000 });
-
-                // Enhanced content processing for images and mixed content
-                if (results.content instanceof Array && results.content.length !== 0) {
-                    const processedContent: (TextBlockParam | ImageBlockParam)[] = [];
-                    processedContent.push({
-                        type: 'text',
-                        text: `Tool "${params.name}" executed successfully. Results:`,
-                    });
-
-                    for (const item of results.content) {
-                        if (item.type === 'image' && item.data) {
-                            // Detect image format from base64 data
-                            const imageData = item.data;
-                            let mediaType: 'image/png' | 'image/jpeg' | 'image/webp' | 'image/gif' = 'image/png';
-
-                            try {
-                                // Check the base64 data signature to determine format
-                                const header = imageData.substring(0, 20);
-
-                                // JPEG signatures
-                                if (header.startsWith('/9j/') || header.startsWith('iVBORw0KGgo')) {
-                                    if (header.startsWith('/9j/')) {
-                                        mediaType = 'image/jpeg';
-                                    } else if (header.startsWith('iVBORw0KGgo')) {
-                                        mediaType = 'image/png';
-                                    }
-                                } else {
-                                    // Try to decode and check binary signature
-                                    const binaryString = atob(imageData.substring(0, 20));
-                                    const bytes = new Uint8Array(binaryString.length);
-                                    for (let i = 0; i < binaryString.length; i++) {
-                                        bytes[i] = binaryString.charCodeAt(i);
-                                    }
-
-                                    // PNG signature: 89 50 4E 47 0D 0A 1A 0A
-                                    if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
-                                        mediaType = 'image/png';
-                                    } else if (bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF) {
-                                        mediaType = 'image/jpeg';
-                                    } else if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46) {
-                                        mediaType = 'image/webp';
-                                    }
-                                }
-                            } catch (error) {
-                                log.warning(`Could not detect image format, using default PNG: ${error}`);
-                                mediaType = 'image/png';
-                            }
-
-                            log.debug(`Detected image format: ${mediaType}`);
-                            processedContent.push({
-                                type: 'image',
-                                source: {
-                                    type: 'base64',
-                                    media_type: mediaType,
-                                    data: imageData,
-                                },
-                            });
-                        } else if (item.type === 'text' && item.text) {
-                            processedContent.push({
-                                type: 'text',
-                                text: item.text,
-                            });
-                        } else if (item.data) {
-                            processedContent.push({
-                                type: 'text',
-                                text: typeof item.data === 'string' ? item.data : JSON.stringify(item.data, null, 2),
-                            });
-                        }
-                    }
-
-                    toolResultBlock.content = processedContent;
+                if (results && typeof results === 'object' && 'content' in results) {
+                    toolResultBlock.content = this.processToolResults(results as CallToolResult, params.name);
                 } else {
+                    log.warning(`Tool ${params.name} returned unexpected result format:`, results);
                     toolResultBlock.content = [{
                         type: 'text',
-                        text: `No results retrieved from ${params.name}`,
+                        text: `Tool "${params.name}" returned unexpected result format: ${JSON.stringify(results, null, 2)}`,
                     }];
-                    toolResultBlock.is_error = true;
                 }
             } catch (error) {
                 log.error(`Error when calling tool ${params.name}: ${error}`);
@@ -578,5 +509,87 @@ export class ConversationManager {
         // Implement logic to handle the notification
         log.info(`Handling notification: ${JSON.stringify(notification)}`);
         // You can update the conversation or perform other actions based on the notification
+    }
+
+    /**
+     * Process tool call results and convert them into appropriate content blocks
+     */
+    private processToolResults(results: CallToolResult, toolName: string): (TextBlockParam | ImageBlockParam)[] {
+        if (!results.content || !Array.isArray(results.content) || results.content.length === 0) {
+            return [{
+                type: 'text',
+                text: `No results retrieved from ${toolName}`,
+            }];
+        }
+        const processedContent: (TextBlockParam | ImageBlockParam)[] = [];
+        processedContent.push({
+            type: 'text',
+            text: `Tool "${toolName}" executed successfully. Results:`,
+        });
+        for (const item of results.content) {
+            if (item.type === 'image' && item.data) {
+                const mediaType = this.detectImageFormat(item.data);
+                log.debug(`Detected image format: ${mediaType}`);
+                processedContent.push({
+                    type: 'image',
+                    source: {
+                        type: 'base64',
+                        media_type: mediaType,
+                        data: item.data,
+                    },
+                });
+                continue;
+            }
+            if (item.type === 'text' && item.text) {
+                processedContent.push({
+                    type: 'text',
+                    text: item.text,
+                });
+                continue;
+            }
+            // Other data types
+            if (item.data) {
+                processedContent.push({
+                    type: 'text',
+                    text: typeof item.data === 'string' ? item.data : JSON.stringify(item.data, null, 2),
+                });
+            }
+        }
+        return processedContent;
+    }
+
+    /**
+     * Detect image format from base64 data
+     */
+    private detectImageFormat(imageData: string): 'image/png' | 'image/jpeg' | 'image/webp' | 'image/gif' {
+        try {
+            const header = imageData.substring(0, 20);
+            if (header.startsWith('/9j/')) {
+                return 'image/jpeg';
+            }
+            if (header.startsWith('iVBORw0KGgo')) {
+                return 'image/png';
+            }
+            // Binary signature detection
+            const binaryString = atob(imageData.substring(0, 20));
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+                bytes[i] = binaryString.charCodeAt(i);
+            }
+            // PNG signature: 89 50 4E 47 0D 0A 1A 0A
+            if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
+                return 'image/png';
+            }
+            if (bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF) {
+                return 'image/jpeg';
+            }
+            if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46) {
+                return 'image/webp';
+            }
+            return 'image/png'; // Default fallback
+        } catch (error) {
+            log.warning(`Could not detect image format, using default PNG: ${error}`);
+            return 'image/png';
+        }
     }
 }

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -509,7 +509,7 @@ function appendToolBlock(item, key) {
         } else {
             resultContent = formatAnyContent(item.content);
         }
-        
+
         const contentLength = typeof item.content === 'string'
             ? item.content.length
             : JSON.stringify(item.content || '').length;

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -456,36 +456,37 @@ function appendToolBlock(item, key) {
         let statusClass = 'success';
         let statusIcon = 'fa-check-circle';
         let statusText = 'Success';
-        
+
         if (item.is_error) {
             statusClass = 'error';
             statusIcon = 'fa-exclamation-circle';
             statusText = 'Error';
         }
-        
+
         if (Array.isArray(item.content)) {
-            resultContent = item.content.map(contentItem => {
+            resultContent = item.content.map((contentItem) => {
                 if (typeof contentItem === 'object' && contentItem.type === 'image') {
                     // Handle both formats: direct data and Anthropic source format
                     let imageData = contentItem.data;
                     let mediaType = 'image/png'; // default fallback
-                    
+
                     if (!imageData && contentItem.source && contentItem.source.data) {
                         imageData = contentItem.source.data;
                         mediaType = contentItem.source.media_type || 'image/png';
                     }
-                    
+
                     if (imageData) {
                         return `<div class="image-result">
                             ${contentItem.text ? `<p>${contentItem.text}</p>` : ''}
                             <img src="data:${mediaType};base64,${imageData}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Tool result image" />
                         </div>`;
                     }
-                } else if (typeof contentItem === 'object' && contentItem.type === 'text') {
-                    return `<div class="text-result">${formatMarkdown(contentItem.text || '')}</div>`;
-                } else {
                     return formatAnyContent(contentItem);
                 }
+                if (typeof contentItem === 'object' && contentItem.type === 'text') {
+                    return `<div class="text-result">${formatMarkdown(contentItem.text || '')}</div>`;
+                }
+                return formatAnyContent(contentItem);
             }).join('');
         } else {
             resultContent = formatAnyContent(item.content);
@@ -539,7 +540,7 @@ function formatAnyContent(content) {
         // Try JSON parse for other content
         try {
             const parsed = JSON.parse(content);
-            return '<pre><code>' + escapeHTML(JSON.stringify(parsed, null, 2)) + '</code></pre>';
+            return `<pre><code>${escapeHTML(JSON.stringify(parsed, null, 2))}</code></pre>`;
         } catch {
             return formatMarkdown(content);
         }
@@ -553,18 +554,18 @@ function formatAnyContent(content) {
         }
         // Handle array of content blocks
         if (Array.isArray(content)) {
-            return content.map(item => {
+            return content.map((item) => {
                 if (item.type === 'image' && item.data) {
                     const mediaType = item.source?.media_type || 'image/png';
                     return `<img src="data:${mediaType};base64,${item.data}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Generated image" />`;
-                } else if (item.type === 'text') {
+                } if (item.type === 'text') {
                     return formatMarkdown(item.text || '');
                 }
                 return formatAnyContent(item);
             }).join('<br>');
         }
         // Plain object → JSON
-        return '<pre><code>' + escapeHTML(JSON.stringify(content, null, 2)) + '</code></pre>';
+        return `<pre><code>${escapeHTML(JSON.stringify(content, null, 2))}</code></pre>`;
     }
 
     // fallback

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -468,13 +468,17 @@ function appendToolBlock(item, key) {
                 if (typeof contentItem === 'object' && contentItem.type === 'image') {
                     // Handle both formats: direct data and Anthropic source format
                     let imageData = contentItem.data;
+                    let mediaType = 'image/png'; // default fallback
+                    
                     if (!imageData && contentItem.source && contentItem.source.data) {
                         imageData = contentItem.source.data;
+                        mediaType = contentItem.source.media_type || 'image/png';
                     }
+                    
                     if (imageData) {
                         return `<div class="image-result">
                             ${contentItem.text ? `<p>${contentItem.text}</p>` : ''}
-                            <img src="data:image/png;base64,${imageData}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Tool result image" />
+                            <img src="data:${mediaType};base64,${imageData}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Tool result image" />
                         </div>`;
                     }
                 } else if (typeof contentItem === 'object' && contentItem.type === 'text') {
@@ -544,13 +548,15 @@ function formatAnyContent(content) {
     if (content && typeof content === 'object') {
         // Check if object contains image data
         if (content.type === 'image' && content.data) {
-            return `<img src="data:image/png;base64,${content.data}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Generated image" />`;
+            const mediaType = content.source?.media_type || 'image/png';
+            return `<img src="data:${mediaType};base64,${content.data}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Generated image" />`;
         }
         // Handle array of content blocks
         if (Array.isArray(content)) {
             return content.map(item => {
                 if (item.type === 'image' && item.data) {
-                    return `<img src="data:image/png;base64,${item.data}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Generated image" />`;
+                    const mediaType = item.source?.media_type || 'image/png';
+                    return `<img src="data:${mediaType};base64,${item.data}" style="max-width: 100%; height: auto; border-radius: 8px; margin: 10px 0;" alt="Generated image" />`;
                 } else if (item.type === 'text') {
                     return formatMarkdown(item.text || '');
                 }

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -472,12 +472,12 @@ function appendToolBlock(item, key) {
     } else if (item.type === 'tool_result') {
         let resultContent = '<em>No content</em>';
         let statusClass = 'success';
-        let statusIcon = 'fa-check-circle';
+        let statusIcon = '✅';
         let statusText = 'Success';
 
         if (item.is_error) {
             statusClass = 'error';
-            statusIcon = 'fa-exclamation-circle';
+            statusIcon = '❌';
             statusText = 'Error';
         }
 
@@ -509,15 +509,21 @@ function appendToolBlock(item, key) {
         } else {
             resultContent = formatAnyContent(item.content);
         }
+        
+        const contentLength = typeof item.content === 'string'
+            ? item.content.length
+            : JSON.stringify(item.content || '').length;
+
         container.innerHTML = `
 <details class="tool-details">
     <summary>
         <div class="tool-header">
-            <div class="tool-icon ${statusClass}">
-                <i class="fas ${statusIcon}"></i>
+            <div class="tool-icon ${statusClass}" style="background-color: ${statusClass === 'success' ? '#d4edda' : '#f8d7da'}; border-radius: 4px; padding: 4px;">
+                <span style="font-size: 1.2em;">${statusIcon}</span>
             </div>
             <div class="tool-info">
                 <div class="tool-call">Tool result: ${statusText}</div>
+                <div class="tool-meta">${contentLength} chars</div>
             </div>
             <div class="tool-status">
                 <i class="fas fa-chevron-down"></i>

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -471,14 +471,19 @@ function appendToolBlock(item, key) {
 </details>`;
     } else if (item.type === 'tool_result') {
         let resultContent = '<em>No content</em>';
-        let statusClass = 'success';
-        let statusIcon = '✅';
-        let statusText = 'Success';
+        let statusText;
+        let iconHtml;
 
         if (item.is_error) {
-            statusClass = 'error';
-            statusIcon = '❌';
             statusText = 'Error';
+            iconHtml = `<div class="tool-icon error" style="background-color: #f8d7da; border-radius: 4px; padding: 4px;">
+                <span style="font-size: 1.2em;">❌</span>
+            </div>`;
+        } else {
+            statusText = 'Success';
+            iconHtml = `<div class="tool-icon">
+                <i class="fas fa-file-alt"></i>
+            </div>`;
         }
 
         if (Array.isArray(item.content)) {
@@ -518,9 +523,7 @@ function appendToolBlock(item, key) {
 <details class="tool-details">
     <summary>
         <div class="tool-header">
-            <div class="tool-icon ${statusClass}" style="background-color: ${statusClass === 'success' ? '#d4edda' : '#f8d7da'}; border-radius: 4px; padding: 4px;">
-                <span style="font-size: 1.2em;">${statusIcon}</span>
-            </div>
+            ${iconHtml}
             <div class="tool-info">
                 <div class="tool-call">Tool result: ${statusText}</div>
                 <div class="tool-meta">${contentLength} chars</div>

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -476,8 +476,8 @@ function appendToolBlock(item, key) {
 
         if (item.is_error) {
             statusText = 'Error';
-            iconHtml = `<div class="tool-icon error" style="background-color: #f8d7da; border-radius: 4px; padding: 4px;">
-                <span style="font-size: 1.2em;">❌</span>
+            iconHtml = `<div class="tool-icon" style="background-color: #ff3342;">
+                <i class="fas fa-file-alt"></i>
             </div>`;
         } else {
             statusText = 'Success';

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -402,6 +402,34 @@ body {
     background: transparent;
 }
 
+.tool-result-content .image-result {
+    margin: 10px 0;
+    padding: 10px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background: #f9f9f9;
+}
+
+.tool-result-content .text-result {
+    margin: 5px 0;
+}
+
+.tool-icon.success {
+    color: #28a745;
+}
+
+.tool-icon.error {
+    color: #dc3545;
+}
+
+.tool-result-content img {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.tool-result-content img:hover {
+    cursor: pointer;
+}
+
 #inputRow {
     position: fixed;
     bottom: 0;


### PR DESCRIPTION
- Now added so we can see the tool results success or error state.
- I had problems with structure of messages so I added logging conversation state for debugging

- I would like to expand tool results with photos automatically. (Just add "open" to <details>) Do we want that?
- I wanted to check for media types, but didn’t know how to. I am not sure about the part for checking photos signatures - Clause suggested this way how to do it - starting on line 356
- I would like to add: clicking image show it in fullscreen, can I?