### PR TITLE
fix: streamable keep client session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.2",
         "@anthropic-ai/tokenizer": "^0.0.4",
-        "@modelcontextprotocol/sdk": "^1.11.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
         "apify": "^3.3.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.36.2",
     "@anthropic-ai/tokenizer": "^0.0.4",
-    "@modelcontextprotocol/sdk": "^1.11.0",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "apify": "^3.3.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,7 +195,9 @@ app.get('/sse', async (req, res) => {
  * @returns Client instance or throws error
  */
 async function getOrCreateClient(): Promise<Client> {
+    log.debug('Getting or creating MCP client');
     if (!client) {
+        log.debug('Creating new MCP client');
         try {
             client = await createClient(
                 runtimeSettings.mcpUrl,
@@ -250,7 +252,6 @@ app.post('/message', async (req, res) => {
         await Actor.charge({ eventName: Event.QUERY_ANSWERED, count: 1 });
         log.info(`Charged query answered event`);
 
-        await cleanupClient();
         // Send a finished flag
         await broadcastSSE({ role: 'system', content: '', finished: true });
         return res.json({ ok: true });


### PR DESCRIPTION
tester client was recreating client for each session which caused resetting sessionId and thus inconsistencies in tool state. This was also making the tester client so slow - it was always creating a new connection for each message (which takes ~1 - 2 secs for actors-mcp-server running as standby Actor).

Also updated MCP SDK

maybe fixes https://github.com/apify/tester-mcp-client/issues/63