### PR TITLE
fix: client state

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -275,8 +275,6 @@ app.get('/reconnect-mcp-server', async (_req, res) => {
     } catch (err) {
         const error = err as Error;
         return res.json({ ok: false, error: error.message });
-    } finally {
-        await cleanupClient();
     }
 });
 
@@ -335,8 +333,6 @@ app.get('/available-tools', async (_req, res) => {
         const error = err as Error;
         log.error(`Error fetching tools: ${error.message}`);
         return res.status(500).json({ error: 'Failed to fetch tools' });
-    } finally {
-        await cleanupClient();
     }
 });
 


### PR DESCRIPTION
current logic is destroying MCP client and reconnecting on listing tools and reconnect endpoint call. This works on single tenant standby Actor server but not work multi-tenant mcp.apify.com where the session id needs to be preserved