### PR TITLE
fix: set default transport to http-streamable

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -4,9 +4,9 @@
     "schemaVersion": 1,
     "properties": {
         "mcpSseUrl": {
-            "title": "MCP Server Sent Events (SSE) URL",
+            "title": "MCP Server URL",
             "type": "string",
-            "description": "MCP Server Sent Events (SSE) URL for receiving updates from the server.\n\nMake sure that URL path ends with `/sse`",
+            "description": "MCP Server URL for receiving updates from the server.",
             "editor": "hidden"
         },
         "mcpUrl": {
@@ -14,16 +14,16 @@
             "type": "string",
             "description": "URL of the MCP Server for updates. Use `SSEClientTransport` if the URL ends with `/sse`; otherwise, use `HttpStreamableClientTransport`.",
             "editor": "textfield",
-            "default": "https://mcp.apify.com/sse?enableAddingActors=true",
-            "prefill": "https://mcp.apify.com/sse?enableAddingActors=true"
+            "default": "https://mcp.apify.com",
+            "prefill": "https://mcp.apify.com"
         },
         "mcpTransportType": {
             "title": "MCP transport type specification",
             "type": "string",
-            "description": "This setting helps you to override the MCP transport layer if required. Use `SSEClientTransport` for Server Sent Events (2024-11-05) or `HttpStreamableClientTransport` for JSON Response Streamable HTTP (2025-03-26).",
-            "enum": ["sse", "http-streamable-json-response"],
-            "enumTitles": ["SSE (Server Sent Events, 2024-11-05)", "JSON Response Streamable HTTP (2025-03-26)"],
-            "default": "sse"
+            "description": "This setting helps you to override the MCP transport layer if required. Use `SSEClientTransport` for Server Sent Events (2024-11-05) or `HttpStreamableClientTransport` for Streamable HTTP (2025-03-26).",
+            "enum": ["sse", "http-streamable"],
+            "enumTitles": ["SSE (Server Sent Events, 2024-11-05)", "Streamable HTTP (2025-03-26)"],
+            "default": "http-streamable"
         },
         "headers": {
             "title": "HTTP headers",

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Actors MCP Client](https://apify.com/actor-badge?actor=jiri.spilka/tester-mcp-client)](https://apify.com/jiri.spilka/tester-mcp-client)
 
-Implementation of a model context protocol (MCP) client that connects to an MCP server using Server-Sent Events (SSE) and displays the conversation in a chat-like UI.
-It is a standalone Actor server designed for testing MCP servers over SSE.
+Implementation of a model context protocol (MCP) client that connects to an MCP server using HTTP streamable (recommended) or Server-Sent Events (SSE) transport and displays the conversation in a chat-like UI.
+It is a standalone Actor server designed for testing MCP servers over HTTP streamable or SSE.
 It uses [Pay-per-event](https://docs.apify.com/sdk/js/docs/guides/pay-per-event) pricing model.
 
 For more information, see the [Model Context Protocol](https://modelcontextprotocol.org/) website or blogpost [What is MCP and why does it matter?](https://blog.apify.com/what-is-model-context-protocol/).
@@ -16,7 +16,7 @@ Navigate to https://...apify.net to interact with chat-ui interface.
 
 ## 🚀 Main features
 
-- 🔌 Connects to an MCP server using Server-Sent Events (SSE) or Streamable HTTP
+- 🔌 Connects to an MCP server using **HTTP streamable (recommended)** or Server-Sent Events (SSE)
 - 💬 Provides a chat-like UI for displaying tool calls and results
 - 🇦 Connects to an [Apify MCP Server](https://mcp.apify.com) for interacting with one or more Apify Actors
 - 💥 Dynamically uses tools based on context and user queries (if supported by a server)
@@ -36,9 +36,9 @@ When connected to [Apify MCP Server](https://mcp.apify.com/) the Tester MCP Clie
 
 ## 📖 How does it work?
 
-The Apify MCP Client connects to a running MCP server over Server-Sent Events (SSE) and it does the following:
+The Apify MCP Client connects to a running MCP server over **HTTP streamable** (recommended) or SSE and it does the following:
 
-- Initiates an SSE connection to the MCP server `/sse`.
+- Initiates a streamable HTTP connection to the MCP server or SSE connection (`/sse`).
 - Sends user queries to the MCP server via `POST /message`.
 - Receives real-time streamed responses (via `GET /sse`) that may include LLM output, and **tool usage** blocks
 - Based on the LLM response, orchestrates tool calls and displays the conversation
@@ -48,6 +48,10 @@ The Apify MCP Client connects to a running MCP server over Server-Sent Events (S
 
 - Test any MCP server over SSE
 - Test [Apify MCP Server](https://mcp.apify.com/) and the ability to dynamically select amongst thousands of tools
+
+Learn about the key features and capabilities in the **Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude** video
+
+[Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude](https://www.youtube.com/watch?v=BKu8H91uCTg&ab_channel=Apify).
 
 ### Normal Mode (on Apify)
 
@@ -62,9 +66,8 @@ INFO  Navigate to https://......runs.apify.net in your browser to interact with 
 
 ## 💰 Pricing
 
-The Apify MCP Client is free to use. You only pay for LLM provider usage and resources consumed on the Apify platform.
-
-This Actor uses a modern and flexible approach for AI Agents monetization and pricing called [Pay-per-event](https://docs.apify.com/sdk/js/docs/guides/pay-per-event).
+The Apify MCP client uses a modern and flexible approach for AI Agents monetization and pricing called [Pay-per-event](https://docs.apify.com/sdk/js/docs/guides/pay-per-event).
+You only need to have Apify account and you can use it, LLM provider API key is not required but you can supply it if you want to use your own LLM provider.
 
 Events charged:
 - Actor start (based on memory used, charged per 128 MB unit)
@@ -78,10 +81,10 @@ Definitely enough to test your MCP server!
 ## 📖 How it works
 
 ```plaintext
-Browser ← (SSE) → Tester MCP Client  ← (SSE) → MCP Server
+Browser ← (SSE) → Tester MCP Client  ← (HTTP streamable or SSE) → MCP Server
 ```
 We create this chain to keep any custom bridging logic inside the Tester MCP Client, while leaving the main MCP Server unchanged.
-The browser uses SSE to communicate with the Tester MCP Client, and the Tester MCP Client relies on SSE to talk to the MCP Server.
+The browser uses SSE to communicate with the Tester MCP Client, and the Tester MCP Client relies on HTTP streamable or SSE to talk to the MCP Server.
 This separates extra client-side logic from the core server, making it easier to maintain and debug.
 
 1. Navigate to `https://tester-mcp-client.apify.actor?token=YOUR-API-TOKEN` (or http://localhost:3000 if you are running it locally).
@@ -96,7 +99,7 @@ This separates extra client-side logic from the core server, making it easier to
 
 ### Local development
 
-The Tester MCP Client Actor is open source and available on [GitHub](https://github.com/apify/rag-web-browser), allowing you to modify and develop it as needed.
+The Tester MCP Client Actor is open source and available on [GitHub](https://github.com/apify/tester-mcp-client), allowing you to modify and develop it as needed.
 
 Download the source code:
 
@@ -135,9 +138,10 @@ The client does not support all MCP features, such as Prompts and Resource.
 ## References
 
 - [Model Context Protocol](https://modelcontextprotocol.org/)
-- [Apify Actors MCP Server](https://apify.com/apify/actors-mcp-server)
+- [Apify MCP Server](https://mcp.apify.com)
 - [Apify MCP Server](https://docs.apify.com/platform/integrations/mcp)
 - [Pay-per-event pricing model](https://docs.apify.com/sdk/js/docs/guides/pay-per-event)
 - [What are AI Agents?](https://blog.apify.com/what-are-ai-agents/)
 - [What is MCP and why does it matter?](https://blog.apify.com/what-is-model-context-protocol/)
 - [How to use MCP with Apify Actors](https://blog.apify.com/how-to-use-mcp/)
+- [Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude](https://www.youtube.com/watch?v=BKu8H91uCTg&ab_channel=Apify)

--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -6,10 +6,12 @@ import { ToolListChangedNotificationSchema, LoggingMessageNotificationSchema } f
 import type { LoggingMessageNotification, ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
 import { log } from 'apify';
 
+import type { McpTransportType } from './types.js';
+
 /**
  * Create a client for the MCP server
  * @param serverUrl - The URL of the MCP server
- * @param mcpTransport - The transport method to use for the MCP server. Either 'sse' or 'http-streamable-json-response'
+ * @param mcpTransport - The transport method to use for the MCP server. Either 'sse' or 'http-streamable'
  * @param customHeaders - Custom headers to send to the MCP server
  * @param onToolsUpdate - A function to call when the tools list changes. Used to update the tools in the conversation manager
  * @param onNotification - A function to call when a notification is received. Used to log notifications
@@ -17,7 +19,7 @@ import { log } from 'apify';
  */
 export async function createClient(
     serverUrl: string,
-    mcpTransport: 'sse' | 'http-streamable-json-response',
+    mcpTransport: McpTransportType,
     customHeaders: Record<string, string> | null,
     onToolsUpdate: (listTools: ListToolsResult) => Promise<void>,
     onNotification: (notification: LoggingMessageNotification) => void,

--- a/src/input.ts
+++ b/src/input.ts
@@ -14,7 +14,13 @@ export function getChargeForTokens() {
  * @returns input
  */
 export function processInput(originalInput: Partial<Input> | Partial<StandbyInput>): Input {
-    const input = { ...defaults, ...originalInput } as StandbyInput;
+    // Normalize deprecated transport type before casting
+    let { mcpTransportType } = originalInput;
+    if (mcpTransportType === 'http-streamable-json-response') {
+        mcpTransportType = 'http-streamable';
+    }
+
+    const input = { ...defaults, ...originalInput, mcpTransportType } as StandbyInput;
 
     // MCP SSE URL is deprecated, use MCP URL instead
     if (input.mcpSseUrl && !input.mcpUrl) {
@@ -24,14 +30,14 @@ export function processInput(originalInput: Partial<Input> | Partial<StandbyInpu
         throw new Error(`MCP Server URL is not provided. ${MISSING_PARAMETER_ERROR}: 'mcpUrl'`);
     }
 
-    if (input.mcpTransportType === 'http-streamable-json-response' && input.mcpUrl.includes('/sse')) {
+    if (input.mcpTransportType === 'http-streamable' && input.mcpUrl.includes('/sse')) {
         throw new Error(`MCP URL includes /sse path, but the transport is set to 'http-streamable'. This is very likely a mistake.`);
     }
 
     if (input.mcpUrl.includes('/sse')) {
         input.mcpTransportType = 'sse';
     } else {
-        input.mcpTransportType = 'http-streamable-json-response';
+        input.mcpTransportType = 'http-streamable';
     }
 
     if (!input.headers) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,7 @@ async function getOrCreateClient(): Promise<Client> {
  * Helper function to handle client cleanup based on transport type
  */
 async function cleanupClient(): Promise<void> {
-    if (input.mcpTransportType === 'http-streamable-json-response' && client) {
+    if (input.mcpTransportType === 'http-streamable' && client) {
         try {
             await client.close();
             client = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources/index.js';
 
+export type McpTransportType = 'sse' | 'http-streamable' | 'http-streamable-json-response';
+
 export type Input = {
     llmProviderApiKey: string,
     modelName: string,
@@ -11,7 +13,10 @@ export type Input = {
      */
     mcpSseUrl: string,
     mcpUrl: string,
-    mcpTransportType: 'sse' | 'http-streamable-json-response',
+    /**
+     * Use 'sse' or 'http-streamable'. 'http-streamable-json-response' is deprecated.
+     */
+    mcpTransportType: McpTransportType,
     systemPrompt: string,
     toolCallTimeoutSec: number,
 };

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+
+import { processInput } from '../src/input.js';
+import type { StandbyInput } from '../src/types.js';
+
+describe('processInput', () => {
+    it('should convert http-streamable-json-response to http-streamable', () => {
+        const input = {
+            mcpUrl: 'https://mcp.apify.com',
+            mcpTransportType: 'http-streamable-json-response',
+            modelName: 'claude-3-5-haiku-latest',
+        } as unknown as Partial<StandbyInput>;
+        const result = processInput(input);
+        expect(result.mcpTransportType).toBe('http-streamable');
+    });
+
+    it('should keep http-streamable as is', () => {
+        const input: Partial<StandbyInput> = {
+            mcpUrl: 'https://mcp.apify.com',
+            mcpTransportType: 'http-streamable',
+            modelName: 'claude-3-5-haiku-latest',
+        };
+
+        const result = processInput(input);
+
+        expect(result.mcpTransportType).toBe('http-streamable');
+    });
+
+    it('should set mcpTransportType to http-streamable if mcpUrl does not include /sse', () => {
+        const input: Partial<StandbyInput> = {
+            mcpUrl: 'https://mcp.apify.com',
+            modelName: 'claude-3-5-haiku-latest',
+        };
+
+        const result = processInput(input);
+
+        expect(result.mcpTransportType).toBe('http-streamable');
+    });
+
+    it('should set mcpTransportType to sse if mcpUrl includes /sse', () => {
+        const input: Partial<StandbyInput> = {
+            mcpUrl: 'https://mcp.apify.com/sse',
+            modelName: 'claude-3-5-haiku-latest',
+        };
+
+        const result = processInput(input);
+
+        expect(result.mcpTransportType).toBe('sse');
+    });
+
+    it('should throw an error if mcpTransportType is http-streamable but mcpUrl includes /sse', () => {
+        const input: Partial<StandbyInput> = {
+            mcpUrl: 'https://mcp.apify.com/sse',
+            mcpTransportType: 'http-streamable',
+            modelName: 'claude-3-5-haiku-latest',
+        };
+
+        expect(() => processInput(input)).toThrow();
+    });
+});


### PR DESCRIPTION
- **fix: conversation structure (#76)**
- ** fix: client state #78**
- **Add claude 4 support (#77)**
- **feat: update README.md (#80)**
- **feat: change default settings to mcp.apify.com (#81)**
- **Fix/better json formatting (#82)**
- **Add implementation for #67 (#72)**
- **fix: use mcp.apify.com streamable transport by default**
