### PR TITLE
fix: rename http-stremable to http

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -21,9 +21,9 @@
             "title": "MCP transport type specification",
             "type": "string",
             "description": "This setting helps you to override the MCP transport layer if required. Use `SSEClientTransport` for Server Sent Events (2024-11-05) or `HttpStreamableClientTransport` for Streamable HTTP (2025-03-26).",
-            "enum": ["sse", "http-streamable"],
-            "enumTitles": ["SSE (Server Sent Events, 2024-11-05)", "Streamable HTTP (2025-03-26)"],
-            "default": "http-streamable"
+            "enum": ["http", "sse", "http-streamable-json-response"],
+            "enumTitles": ["Streamable HTTP (2025-03-26)", "SSE (Server Sent Events, 2024-11-05)", "Deprecated"],
+            "default": "http"
         },
         "headers": {
             "title": "HTTP headers",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Apify MCP Client connects to a running MCP server over **HTTP streamable** (
 
 Learn about the key features and capabilities in the **Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude** video
 
-[Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude](https://www.youtube.com/watch?v=BKu8H91uCTg&ab_channel=Apify).
+[Apify MCP Server Tutorial: Integrate 5,000+ Apify Actors and Agents Into Claude](https://www.youtube.com/watch?v=BKu8H91uCTg)
 
 ### Normal Mode (on Apify)
 

--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -11,7 +11,7 @@ import type { McpTransportType } from './types.js';
 /**
  * Create a client for the MCP server
  * @param serverUrl - The URL of the MCP server
- * @param mcpTransport - The transport method to use for the MCP server. Either 'sse' or 'http-streamable'
+ * @param mcpTransport - The transport method to use for the MCP server. Either 'sse' or 'http'
  * @param customHeaders - Custom headers to send to the MCP server
  * @param onToolsUpdate - A function to call when the tools list changes. Used to update the tools in the conversation manager
  * @param onNotification - A function to call when a notification is received. Used to log notifications

--- a/src/input.ts
+++ b/src/input.ts
@@ -17,7 +17,7 @@ export function processInput(originalInput: Partial<Input> | Partial<StandbyInpu
     // Normalize deprecated transport type before casting
     let { mcpTransportType } = originalInput;
     if (mcpTransportType === 'http-streamable-json-response') {
-        mcpTransportType = 'http-streamable';
+        mcpTransportType = 'http';
     }
 
     const input = { ...defaults, ...originalInput, mcpTransportType } as StandbyInput;
@@ -30,14 +30,14 @@ export function processInput(originalInput: Partial<Input> | Partial<StandbyInpu
         throw new Error(`MCP Server URL is not provided. ${MISSING_PARAMETER_ERROR}: 'mcpUrl'`);
     }
 
-    if (input.mcpTransportType === 'http-streamable' && input.mcpUrl.includes('/sse')) {
-        throw new Error(`MCP URL includes /sse path, but the transport is set to 'http-streamable'. This is very likely a mistake.`);
+    if (input.mcpTransportType === 'http' && input.mcpUrl.includes('/sse')) {
+        throw new Error(`MCP URL includes /sse path, but the transport is set to 'http'. This is very likely a mistake.`);
     }
 
     if (input.mcpUrl.includes('/sse')) {
         input.mcpTransportType = 'sse';
     } else {
-        input.mcpTransportType = 'http-streamable';
+        input.mcpTransportType = 'http';
     }
 
     if (!input.headers) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,7 @@ async function getOrCreateClient(): Promise<Client> {
  * Helper function to handle client cleanup based on transport type
  */
 async function cleanupClient(): Promise<void> {
-    if (input.mcpTransportType === 'http-streamable' && client) {
+    if (input.mcpTransportType === 'http' && client) {
         try {
             await client.close();
             client = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources/index.js';
 
-export type McpTransportType = 'sse' | 'http-streamable' | 'http-streamable-json-response';
+/**
+ * Use 'sse' or 'http' for MCP servers that support SSE.
+ */
+export type McpTransportType = 'sse' | 'http' | 'http-streamable-json-response';
 
 export type Input = {
     llmProviderApiKey: string,
@@ -14,7 +17,7 @@ export type Input = {
     mcpSseUrl: string,
     mcpUrl: string,
     /**
-     * Use 'sse' or 'http-streamable'. 'http-streamable-json-response' is deprecated.
+     * Use 'sse' or 'http'.
      */
     mcpTransportType: McpTransportType,
     systemPrompt: string,

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -4,29 +4,29 @@ import { processInput } from '../src/input.js';
 import type { StandbyInput } from '../src/types.js';
 
 describe('processInput', () => {
-    it('should convert http-streamable-json-response to http-streamable', () => {
+    it('should convert http-streamable-json-response to http', () => {
         const input = {
             mcpUrl: 'https://mcp.apify.com',
             mcpTransportType: 'http-streamable-json-response',
             modelName: 'claude-3-5-haiku-latest',
         } as unknown as Partial<StandbyInput>;
         const result = processInput(input);
-        expect(result.mcpTransportType).toBe('http-streamable');
+        expect(result.mcpTransportType).toBe('http');
     });
 
-    it('should keep http-streamable as is', () => {
+    it('should keep http as is', () => {
         const input: Partial<StandbyInput> = {
             mcpUrl: 'https://mcp.apify.com',
-            mcpTransportType: 'http-streamable',
+            mcpTransportType: 'http',
             modelName: 'claude-3-5-haiku-latest',
         };
 
         const result = processInput(input);
 
-        expect(result.mcpTransportType).toBe('http-streamable');
+        expect(result.mcpTransportType).toBe('http');
     });
 
-    it('should set mcpTransportType to http-streamable if mcpUrl does not include /sse', () => {
+    it('should set mcpTransportType to http if mcpUrl does not include /sse', () => {
         const input: Partial<StandbyInput> = {
             mcpUrl: 'https://mcp.apify.com',
             modelName: 'claude-3-5-haiku-latest',
@@ -34,7 +34,7 @@ describe('processInput', () => {
 
         const result = processInput(input);
 
-        expect(result.mcpTransportType).toBe('http-streamable');
+        expect(result.mcpTransportType).toBe('http');
     });
 
     it('should set mcpTransportType to sse if mcpUrl includes /sse', () => {
@@ -48,10 +48,10 @@ describe('processInput', () => {
         expect(result.mcpTransportType).toBe('sse');
     });
 
-    it('should throw an error if mcpTransportType is http-streamable but mcpUrl includes /sse', () => {
+    it('should throw an error if mcpTransportType is http but mcpUrl includes /sse', () => {
         const input: Partial<StandbyInput> = {
             mcpUrl: 'https://mcp.apify.com/sse',
-            mcpTransportType: 'http-streamable',
+            mcpTransportType: 'http',
             modelName: 'claude-3-5-haiku-latest',
         };
 


### PR DESCRIPTION
- **fix: conversation structure (#76)**
- ** fix: client state #78**
- **Add claude 4 support (#77)**
- **feat: update README.md (#80)**
- **feat: change default settings to mcp.apify.com (#81)**
- **Fix/better json formatting (#82)**
- **Add implementation for #67 (#72)**
- **fix: use mcp.apify.com streamable transport by default (#87)**
- **Rename http-streamable simply to http**
