### PR TITLE
fix: headers input leak by marking as secret

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -29,6 +29,7 @@
             "title": "HTTP headers",
             "type": "object",
             "description": "HTTP headers to be sent with the request to the MCP server. If you are using Apify's MCP server, headers are NOT required",
+            "isSecret": true,
             "editor": "json"
         },
         "systemPrompt": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/sdk-trace-base": "^2.0.1",
         "@opentelemetry/sdk-trace-node": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "apify": "^3.3.2",
+        "apify": "^3.4.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "eventsource": "^3.0.2",
@@ -100,15 +100,15 @@
       "license": "MIT"
     },
     "node_modules/@apify/consts": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.37.0.tgz",
-      "integrity": "sha512-GCK7wZcUPnHMUpoxd1tgbDgojdgcdxpnaF8UX5h5/hq5ZPdlik7EP2CkU6MpRfYxYl8T5LOsANUJvdB6bGthKA==",
+      "version": "2.44.0",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.44.0.tgz",
+      "integrity": "sha512-s0lqGd9IyA6S1SW46VT+q8j/n65tvDWPM0g7S8UQZ4rkbIC8Ti+DZp1Zuy88fMwGfh7BT1cFoJS3FBV9iUc+KQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/datastructures": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.2.tgz",
-      "integrity": "sha512-IN9A0s2SCHoZZE1tf4xKgk4fxHM5/0I/UrXhWbn/rSv7E5sA2o0NyHdwcMY2Go9f5qd+E7VAbX6WnESTE6GLeA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@apify/datastructures/-/datastructures-2.0.3.tgz",
+      "integrity": "sha512-E6yQyc/XZDqJopbaGmhzZXMJqwGf96ELtDANZa0t68jcOAJZS+pF7YUfQOLszXq6JQAdnRvTH2caotL6urX7HA==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/eslint-config": {
@@ -134,23 +134,23 @@
       }
     },
     "node_modules/@apify/input_secrets": {
-      "version": "1.1.63",
-      "resolved": "https://registry.npmjs.org/@apify/input_secrets/-/input_secrets-1.1.63.tgz",
-      "integrity": "sha512-BkIf6fzprVfj2VRVhq9OO8JFuqlMP6ldh6fCc5799C2/5l+quYTVMaP4uG4rTxq+qcuBvrA0X70hQdWbIwIikw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@apify/input_secrets/-/input_secrets-1.2.4.tgz",
+      "integrity": "sha512-ZoP528cRRd8Wsn4Fjw/oL8gXkweUf0M9jPmWN7blYp6pG3O7PTn4HfJhNtpoklBEDNqdl4Tfn4Q4Ug51VVTVMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/log": "^2.5.13",
-        "@apify/utilities": "^2.12.2",
+        "@apify/log": "^2.5.21",
+        "@apify/utilities": "^2.18.1",
         "ow": "^0.28.2"
       }
     },
     "node_modules/@apify/log": {
-      "version": "2.5.13",
-      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.13.tgz",
-      "integrity": "sha512-gxvWyD9JWBkLoTX7UfQ4s0F32/UfF4T8TG4jAl2CE0vNKr0COOJFkLmmyWnTNSVDL+yGC+LZp3mtbPnB+l6Sog==",
+      "version": "2.5.21",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.21.tgz",
+      "integrity": "sha512-qup6+em6ifqBSobPUdRLIO3a2c1eANvTfHpFhKQnqydQeuPE6reGFHNtJ+GJHc+vzb3Yw4xgJ3E5QJsr3X/D4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.37.0",
+        "@apify/consts": "^2.44.0",
         "ansi-colors": "^4.1.1"
       }
     },
@@ -170,18 +170,18 @@
       }
     },
     "node_modules/@apify/pseudo_url": {
-      "version": "2.0.54",
-      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.54.tgz",
-      "integrity": "sha512-HYUQvTgFHxnPS3mOL/xDvNv9Thp4ahW4Dwgim6txtsHRLRNuRBmrRtPNBuYIbpIO9LUKVpboXuA6D9nQXtBAlg==",
+      "version": "2.0.62",
+      "resolved": "https://registry.npmjs.org/@apify/pseudo_url/-/pseudo_url-2.0.62.tgz",
+      "integrity": "sha512-Q7Mj1XkYhMCB87JE2yCbUxt4A8Hk678KEeGVGCtl8/muE5Da4glYsGrbceP3uAsTc51Caus/Vnkr7g+9Jm3f0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/log": "^2.5.13"
+        "@apify/log": "^2.5.21"
       }
     },
     "node_modules/@apify/timeout": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.1.tgz",
-      "integrity": "sha512-sLIuOqfySki/7AXiQ1yZoCI07vX6aYFLgP6YaJ8e8YLn8CFsRERma/Crxcz0zyCaxhc7C7EPgcs1O+p/djZchw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@apify/timeout/-/timeout-0.3.2.tgz",
+      "integrity": "sha512-JnOLIOpqfm366q7opKrA6HrL0iYRpYYDn8Mi77sMR2GZ1fPbwMWCVzN23LJWfJV7izetZbCMrqRUXsR1etZ7dA==",
       "license": "Apache-2.0"
     },
     "node_modules/@apify/tsconfig": {
@@ -192,13 +192,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@apify/utilities": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.12.2.tgz",
-      "integrity": "sha512-vFH08HQxRM6oz+7DjE7Q0t9xU52ZFOXXIqMPK+U57VChEVGS+n2UVXxSMw/l8w3bql+r8vPIep4cMk5XwcaYQA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.18.1.tgz",
+      "integrity": "sha512-KuDPrLMl51aAAMUVbCRS9za3u+a5EL1yTbApec+USkZkhSlskL2OFeUucbKA4Dl92fpoPoL3uJqdaZl5NoD1+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apify/consts": "^2.37.0",
-        "@apify/log": "^2.5.13"
+        "@apify/consts": "^2.44.0",
+        "@apify/log": "^2.5.21"
       }
     },
     "node_modules/@arizeai/openinference-semantic-conventions": {
@@ -208,9 +208,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@crawlee/core": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.12.2.tgz",
-      "integrity": "sha512-vwHO1Rg1uxS1oEkF9VMHGiKhLc4ojy0FoJeX2Pq08ibiOIkWkcx8EvA32aEPeAVAvnpwy1TNCFpiiawtUgNKxA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@crawlee/core/-/core-3.14.1.tgz",
+      "integrity": "sha512-SEcAqUWh9jDVHR3IZe/2pO/6H7CtHAC6ny96u1r5tEpzVjhY2ZL9Rokf+8a80ptSx9MKg5FaLAGxD1NUeluEUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/consts": "^2.20.0",
@@ -219,9 +219,9 @@
         "@apify/pseudo_url": "^2.0.30",
         "@apify/timeout": "^0.3.0",
         "@apify/utilities": "^2.7.10",
-        "@crawlee/memory-storage": "3.12.2",
-        "@crawlee/types": "3.12.2",
-        "@crawlee/utils": "3.12.2",
+        "@crawlee/memory-storage": "3.14.1",
+        "@crawlee/types": "3.14.1",
+        "@crawlee/utils": "3.14.1",
         "@sapphire/async-queue": "^1.5.1",
         "@vladfrangu/async_event_emitter": "^2.2.2",
         "csv-stringify": "^6.2.0",
@@ -231,7 +231,7 @@
         "minimatch": "^9.0.0",
         "ow": "^0.28.1",
         "stream-json": "^1.8.0",
-        "tldts": "^6.0.0",
+        "tldts": "^7.0.0",
         "tough-cookie": "^5.0.0",
         "tslib": "^2.4.0",
         "type-fest": "^4.0.0"
@@ -241,13 +241,13 @@
       }
     },
     "node_modules/@crawlee/memory-storage": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.12.2.tgz",
-      "integrity": "sha512-KUnTpYIzYy8Fnyqf2JdufyM6Nd/1/nUsrHF3hFUdQhEfby0yX8kgc9UIF8OKieGfqUuYMKdfpeWyB8jRPp6Jyw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@crawlee/memory-storage/-/memory-storage-3.14.1.tgz",
+      "integrity": "sha512-p99UHF6oAcnJ532IC/B+tlN64RfSXzXvAZac/QLhVXo9h7MBrqSa28iwbkIS7BTWUJxiF6sjZM6Ut+6IJQVnig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/log": "^2.4.0",
-        "@crawlee/types": "3.12.2",
+        "@crawlee/types": "3.14.1",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/shapeshift": "^3.0.0",
         "content-type": "^1.0.4",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@crawlee/types": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.12.2.tgz",
-      "integrity": "sha512-mdSN8FSOGLzPDyO3wC5k6BvZKv467rvrLsIqqAkiN87TgQI5lwV+k2bBQGdajzcjDQn+taWG67xDbbZg6BvFVw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.14.1.tgz",
+      "integrity": "sha512-IGO1krH5MdlINDwfESwMtYK/fyxeWoN5E9wCpabHvIYabUd6eijcR9mKzercrtMXxNG5RJUt8StSSeue1B0G7g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -274,14 +274,14 @@
       }
     },
     "node_modules/@crawlee/utils": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.12.2.tgz",
-      "integrity": "sha512-Yly1WSm1y0Te1/BtrsbPnrZTIL2eoRvk/kmAgyBOC2o1Icu0QnFqWJh0iAuH7Ed92wYVgk4E/Cr5jYls35xcbQ==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@crawlee/utils/-/utils-3.14.1.tgz",
+      "integrity": "sha512-40IWYdgXeX7uGxvM0POEZ7+ZZkjBkmenBWc9Q7ECzeAHqzpMxZU56H8l8bpcj8Xzw26nI3osfkeR4uClEWbjew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/log": "^2.4.0",
         "@apify/ps-tree": "^1.2.0",
-        "@crawlee/types": "3.12.2",
+        "@crawlee/types": "3.14.1",
         "@types/sax": "^1.2.7",
         "cheerio": "1.0.0-rc.12",
         "file-type": "^20.0.0",
@@ -1916,9 +1916,9 @@
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.1.tgz",
-      "integrity": "sha512-QWLl2P+rsCJeofkDNIT3WFmb6NrRud1SUYW8dIhXK/46XFV8Q/g7Bsvib0Askb0reRLe+WYPeeE+l5cH7SlkuQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.0.2.tgz",
+      "integrity": "sha512-d9xRovfKNz1SKieM0qJdO+PQonjnnIfSNWfHYnBSJ9hkjm0ZPw6HlxscDXYstp3z+7V2GOFHc+J0CYrYTjqCJw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1940,17 +1940,17 @@
       }
     },
     "node_modules/@tokenizer/inflate": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.6.tgz",
-      "integrity": "sha512-SdR/i05U7Xhnsq36iyIq/ZiGGw4PKzw4ww3bOq80Pjj4wyXpqyTcgrgdDdGlcatnlvzNJx8CQw3hp6QZvkUwhA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.7",
+        "debug": "^4.4.0",
         "fflate": "^0.8.2",
         "token-types": "^6.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -2546,20 +2546,20 @@
       }
     },
     "node_modules/apify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/apify/-/apify-3.3.2.tgz",
-      "integrity": "sha512-OFP5YVshd0KxUP4yueUjX/hR5PGC0zzYy0xdcxX8OFAcrkrh8VaeGcOJza5uHpPFRwDnPKhiNa3YzcA3rnAHSQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/apify/-/apify-3.4.4.tgz",
+      "integrity": "sha512-9Xm1Ls4XtbBOwvrB3vB1BF7kvSSErtDtiHis8OGyC1UYFHy7HtqG9skxCtnbMVbYuoYrymLebbK9lY1/qmiqXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/consts": "^2.23.0",
-        "@apify/input_secrets": "^1.1.40",
+        "@apify/input_secrets": "^1.2.0",
         "@apify/log": "^2.4.3",
         "@apify/timeout": "^0.3.0",
-        "@apify/utilities": "^2.9.3",
-        "@crawlee/core": "^3.9.0",
-        "@crawlee/types": "^3.9.0",
-        "@crawlee/utils": "^3.9.0",
-        "apify-client": "^2.12.0",
+        "@apify/utilities": "^2.13.0",
+        "@crawlee/core": "^3.13.0",
+        "@crawlee/types": "^3.13.0",
+        "@crawlee/utils": "^3.13.0",
+        "apify-client": "^2.12.1",
         "fs-extra": "^11.2.0",
         "ow": "^0.28.2",
         "semver": "^7.5.4",
@@ -2571,13 +2571,14 @@
       }
     },
     "node_modules/apify-client": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.12.0.tgz",
-      "integrity": "sha512-h04rPVft8tNjnwZswqF2k46bdHZWsDsfOE8PkmklZ9+/s/mb/Q/dMOXCx0u2+RTc8QoAkYS9LYs97wZyUWpoag==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.13.0.tgz",
+      "integrity": "sha512-tl3u2vyQCTfk7yfD5k8iYrr2yVZH7IwQ9gqu+c5oWqdKVYElhzo8uNuZHL471oajecn4zcLz8HTsdzBAj+/hoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apify/consts": "^2.25.0",
         "@apify/log": "^2.2.6",
+        "@apify/utilities": "^2.18.0",
         "@crawlee/types": "^3.3.0",
         "agentkeepalive": "^4.2.1",
         "async-retry": "^1.3.3",
@@ -2761,13 +2762,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2860,9 +2861,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2879,10 +2880,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001688",
-        "electron-to-chromium": "^1.5.73",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.1"
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2994,9 +2995,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001695",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
-      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3208,9 +3209,9 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -3224,9 +3225,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -3236,9 +3237,9 @@
       }
     },
     "node_modules/csv-stringify": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
-      "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.6.0.tgz",
+      "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==",
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -3550,9 +3551,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.88",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
-      "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
+      "version": "1.5.197",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.197.tgz",
+      "integrity": "sha512-m1xWB3g7vJ6asIFz+2pBUbq3uGmfmln1M9SSvBe4QIFWYrRHylP73zL/3nMjDmwz8V+1xAXQDfBd6+HPW0WvDQ==",
       "license": "ISC"
     },
     "node_modules/encodeurl": {
@@ -3677,15 +3678,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4349,13 +4350,13 @@
       }
     },
     "node_modules/file-type": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.0.0.tgz",
-      "integrity": "sha512-w8Z+QqWtEPIfyoPx9lDhzR52UjY5PfZunJ6lmH48oCR2gVbV52Aaw2bVtbi7P4EAlSpjn8xmNDiRAieYaabEIQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.2.6",
-        "strtok3": "^10.0.1",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
         "uint8array-extras": "^1.4.0"
       },
@@ -4451,9 +4452,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -4481,13 +4482,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4538,9 +4541,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4606,9 +4609,9 @@
       }
     },
     "node_modules/generative-bayesian-network": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.62.tgz",
-      "integrity": "sha512-+zq1/AHdxb+0MXF34krM/IUu/N9gI6llzQg2gf7WMfuzh0nv6xbhb8QyfL48MOJihum7wSE90+/hMXK60X+Kpw==",
+      "version": "2.1.69",
+      "resolved": "https://registry.npmjs.org/generative-bayesian-network/-/generative-bayesian-network-2.1.69.tgz",
+      "integrity": "sha512-k8GgdPT9oCRchU4+7ofh/qpsmvSaOI0znFt/edanyWBBxLjSnjoSU97C15fGqQSdJIZ9uwsCU0RO8xnpLEX95w==",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
@@ -4742,9 +4745,9 @@
       }
     },
     "node_modules/got": {
-      "version": "14.4.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-14.4.5.tgz",
-      "integrity": "sha512-sq+uET8TnNKRNnjEOPJzMcxeI0irT8BBNmf+GtZcJpmhYsQM1DSKmCROUjPWKsXZ5HzwD5Cf5/RV+QD9BSTxJg==",
+      "version": "14.4.7",
+      "resolved": "https://registry.npmjs.org/got/-/got-14.4.7.tgz",
+      "integrity": "sha512-DI8zV1231tqiGzOiOzQWDhsBmncFW7oQDH6Zgy6pDPrqJuVZMtoSgPLLsBZQj8Jg4JFfwoOsDA8NGtLQLnIx2g==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^7.0.1",
@@ -4767,9 +4770,9 @@
       }
     },
     "node_modules/got-scraping": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-4.0.8.tgz",
-      "integrity": "sha512-QCptrUWsxgtP8LAnGZqjuJMwbLELlst1DF/Ba30OUOk7wi/LJtNwuYPUxoielRxTxd9QQ38FL/CWyRVc7m7ZkQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/got-scraping/-/got-scraping-4.1.2.tgz",
+      "integrity": "sha512-LtVwPM5YLnNY7HVT/AK/yDBUg/4yOZSlAjjug2ovrHQseS43QCmO1XosKKXcXrfc6OMX8OnDbAWIauFMcaJ5TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "got": "^14.2.1",
@@ -4855,9 +4858,9 @@
       }
     },
     "node_modules/got/node_modules/form-data-encoder": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.0.2.tgz",
-      "integrity": "sha512-KQVhvhK8ZkWzxKxOr56CPulAhH3dobtuQ4+hNQ+HekH/Wp5gSOafqRAeTphQUJAIk0GBvHZgJ2ZGRWd5kphMuw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -4944,7 +4947,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4969,13 +4971,13 @@
       }
     },
     "node_modules/header-generator": {
-      "version": "2.1.62",
-      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.62.tgz",
-      "integrity": "sha512-L4y1Fush4bkC/3zEurWjiwzeuekAH3HMYA508EZDmvk1wPmcbpV/mq3u3d3fxq7v4oPmaCfsRm1T5DUH19uikA==",
+      "version": "2.1.69",
+      "resolved": "https://registry.npmjs.org/header-generator/-/header-generator-2.1.69.tgz",
+      "integrity": "sha512-J3BK8UtPAR1Lvvfd/qlzmAS1Qb6Q2qx4K1s4FjYVrYvSQnUc7GgOAo9uacebg6WGCdP0eWxtojh7JwEd+AD2Hw==",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist": "^4.21.1",
-        "generative-bayesian-network": "^2.1.62",
+        "generative-bayesian-network": "^2.1.69",
         "ow": "^0.28.1",
         "tslib": "^2.4.0"
       },
@@ -5003,9 +5005,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -5953,9 +5955,9 @@
       "license": "MIT"
     },
     "node_modules/normalize-url": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
+      "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -6237,12 +6239,12 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6259,6 +6261,18 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -6326,19 +6340,6 @@
       ],
       "dependencies": {
         "through": "~2.3"
-      }
-    },
-    "node_modules/peek-readable": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.3.1.tgz",
-      "integrity": "sha512-GVlENSDW6KHaXcd9zkZltB7tCLosKB/4Hg0fqBJkAoBgYG2Tn1xtMgXtSUuMU9AK/gCm/tTdT8mgAeF4YNeeqw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/picocolors": {
@@ -6526,9 +6527,9 @@
       "license": "MIT"
     },
     "node_modules/quick-lru": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.0.tgz",
-      "integrity": "sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.0.1.tgz",
+      "integrity": "sha512-kLjThirJMkWKutUKbZ8ViqFc09tDQhlbQo2MNuVeLWbRauqYP96Sm6nzlQ24F0HFjUNZ4i9+AgldJ9H6DZXi7g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7259,16 +7260,15 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.0.1.tgz",
-      "integrity": "sha512-7OOJepVlvlcgjW/fLNCsIqpNleAoi1y0LTRWGnOpABOSpRmw+65HvnruoOCnjpaQ1efnlYpQ/JwHKuaombnuXQ==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -7394,21 +7394,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.75",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.75.tgz",
-      "integrity": "sha512-+lFzEXhpl7JXgWYaXcB6DqTYXbUArvrWAE/5ioq/X3CdWLbDjpPP4XTrQBmEJ91y3xbe4Fkw7Lxv4P3GWeJaNg==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.11.tgz",
+      "integrity": "sha512-7k7JV/LZpGhFUu2t+YDaMZ1wdPPRNpaCYNQ0NQbSLY3Rbgy+XbCdkXyqRiS9TLXiYAsrv0yiA0OvnxmgRFCdNA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.75"
+        "tldts-core": "^7.0.11"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.75",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.75.tgz",
-      "integrity": "sha512-AOvV5YYIAFFBfransBzSTyztkc3IMfz5Eq3YluaRiEu55nn43Fzaufx70UqEKYr8BoLCach4q8g/bg6e5+/aFw==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.11.tgz",
+      "integrity": "sha512-65eeOpBwWBabh0XqT+zB0vEllq/V3XcrF2fhgMXWWFfNw1yxEjeYg9Vv/B/UNozd0CTR/TohO1ubfn6O6mBW3w==",
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -7434,9 +7434,9 @@
       }
     },
     "node_modules/token-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.4.tgz",
+      "integrity": "sha512-MD9MjpVNhVyH4fyd5rKphjvt/1qj+PtQUz65aFqAZA6XniWAuSFRjLk3e2VALEFlh9OwBpXUN7rfeqSnT/Fmkw==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -7451,9 +7451,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.0.tgz",
-      "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
@@ -7461,6 +7461,24 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/tough-cookie/node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -7547,9 +7565,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
-      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -7742,9 +7760,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/sdk-trace-base": "^2.0.1",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
     "@opentelemetry/semantic-conventions": "^1.36.0",
-    "apify": "^3.3.2",
+    "apify": "^3.4.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "eventsource": "^3.0.2",


### PR DESCRIPTION
Currently the headers are visible in the Actor run input which may contains sensitive data. This PR solves this by marking headers input as secret. The bump in Apify SDK version was needed to automatically decrypt the encrypted JSON string as object (see https://docs.apify.com/platform/actors/development/actor-definition/input-schema/secret-input#read-secret-input-fields)

closes https://github.com/apify/tester-mcp-client/issues/91